### PR TITLE
Styling Changes & More clear information for the end user

### DIFF
--- a/app/Http/Controllers/Api/SidebarController.php
+++ b/app/Http/Controllers/Api/SidebarController.php
@@ -13,7 +13,7 @@ class SidebarController extends Controller
 
         $groups = $user->groups()
             ->select('groups.id', 'groups.name', 'groups.parent_id')
-            ->withCount('credentials')
+            ->withCount(['credentials', 'users'])
             ->get();
 
         $byParent = $groups->groupBy('parent_id');
@@ -30,6 +30,7 @@ class SidebarController extends Controller
                 'name' => $group->name,
                 'url' => route('group', $group->id),
                 'credentialsCount' => $group->credentials_count,
+                'usersCount' => $group->users_count,
                 'children' => $children,
             ];
         };

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -22,6 +22,10 @@ import {
     EllipsisHorizontalIcon,
     ClipboardDocumentListIcon,
     LockClosedIcon,
+    PencilSquareIcon,
+    UsersIcon,
+    ArrowDownTrayIcon,
+    ArrowUpTrayIcon,
 } from '@heroicons/vue/24/outline'
 
 import './bootstrap'
@@ -48,7 +52,10 @@ app.use(VueClipboard)
 app.component('heroicons-plus-icon', PlusIcon)
 app.component('heroicons-arrow-down-on-square-icon', ArrowDownOnSquareIcon)
 app.component('heroicons-arrow-up-on-square-icon', ArrowUpOnSquareIcon)
+app.component('heroicons-arrow-down-tray-icon', ArrowDownTrayIcon)
+app.component('heroicons-arrow-up-tray-icon', ArrowUpTrayIcon)
 app.component('heroicons-user-icon', UserIcon)
+app.component('heroicons-users-icon', UsersIcon)
 app.component('heroicons-cog-6-tooth-icon', Cog6ToothIcon)
 app.component('heroicons-trash-icon', TrashIcon)
 app.component('heroicons-key-icon', KeyIcon)
@@ -57,6 +64,7 @@ app.component('heroicons-chevron-down-icon', ChevronDownIcon)
 app.component('heroicons-folder-icon', FolderIcon)
 app.component('heroicons-folder-open-icon', FolderOpenIcon)
 app.component('heroicons-folder-plus-icon', FolderPlusIcon)
+app.component('heroicons-pencil-square-icon', PencilSquareIcon)
 app.component('heroicons-ellipsis-horizontal-icon', EllipsisHorizontalIcon)
 app.component('heroicons-clipboard-document-list-icon', ClipboardDocumentListIcon)
 app.component('heroicons-lock-closed-icon', LockClosedIcon)

--- a/resources/js/components/AddCredentialsForm.vue
+++ b/resources/js/components/AddCredentialsForm.vue
@@ -4,7 +4,7 @@
             <h3 class="mb-4 text-2xl">Add credentials</h3>
             <div class="mb-4">
                 <div class="mb-2">
-                    <pwdsafe-label class="mb-1" for="name">Name</pwdsafe-label>
+                    <pwdsafe-label class="mb-1" for="name" required>Name</pwdsafe-label>
                     <pwdsafe-input
                         type="text"
                         v-model="name"
@@ -18,13 +18,14 @@
                     <pwdsafe-label class="mb-1" for="url">URL</pwdsafe-label>
                     <pwdsafe-input
                         type="text"
+                        placeholder="https://example.com"
                         v-model="url"
                         id="url"
                         autocomplete="off"
                     ></pwdsafe-input>
                 </div>
                 <div class="mb-2">
-                    <pwdsafe-label class="mb-1" for="user">Username</pwdsafe-label>
+                    <pwdsafe-label class="mb-1" for="user" required>Username</pwdsafe-label>
                     <pwdsafe-input
                         type="text"
                         v-model="user"
@@ -35,7 +36,7 @@
                 </div>
                 <div class="mb-2">
                     <div class="mb-2 flex items-end justify-between gap-x-2">
-                        <pwdsafe-label class="mb-1" for="pass">Password</pwdsafe-label>
+                        <pwdsafe-label class="mb-1" for="pass" required>Password</pwdsafe-label>
                         <pwdsafe-passwordgen @generated="updatePassword"></pwdsafe-passwordgen>
                     </div>
                     <TextareaVue v-model="password" id="pass" rows="5" required></TextareaVue>

--- a/resources/js/components/Button.vue
+++ b/resources/js/components/Button.vue
@@ -2,7 +2,7 @@
     <component
         :is="attrs['href'] ? 'a' : 'button'"
         :class="[
-            'rounded border transition duration-200 disabled:pointer-events-none disabled:opacity-50',
+            'flex items-center rounded border transition duration-200 disabled:pointer-events-none disabled:opacity-50',
             colors[props.theme],
             props.classes,
             sizeclasses[props.size],

--- a/resources/js/components/CredentialCard.vue
+++ b/resources/js/components/CredentialCard.vue
@@ -221,7 +221,12 @@
 <script setup>
 import { ref, reactive, computed } from 'vue'
 import { toClipboard } from '@soerenmartius/vue3-clipboard'
-import { EyeIcon, EyeSlashIcon, ClipboardDocumentListIcon, ArrowTopRightOnSquareIcon } from '@heroicons/vue/24/outline'
+import {
+    EyeIcon,
+    EyeSlashIcon,
+    ClipboardDocumentListIcon,
+    ArrowTopRightOnSquareIcon,
+} from '@heroicons/vue/24/outline'
 import ShareModal from './ShareModal.vue'
 import { decryptCredential, encryptCredentialV2 } from '../vault.js'
 import { showToast } from '../composables/useToast.js'
@@ -301,7 +306,9 @@ defineExpose({
 const saveCredentials = async function () {
     const groupId = credentialint.groupid
 
-    const { data: pubkeysData } = await axios.get(`/api/groups/${groupId}/pubkeys`)
+    const { data: pubkeysData } = await axios.get(
+        `/api/groups/${groupId}/pubkeys`,
+    )
     const encrypted = await Promise.all(
         pubkeysData.users.map(async ({ id, pubkey }) => ({
             userid: id,

--- a/resources/js/components/CredentialCard.vue
+++ b/resources/js/components/CredentialCard.vue
@@ -52,7 +52,7 @@
                         >
                             <input type="hidden" name="_method" value="put" />
                             <div class="mb-2">
-                                <pwdsafe-label for="name" class="mb-1"
+                                <pwdsafe-label for="name" class="mb-1" required
                                     >Name</pwdsafe-label
                                 >
                                 <pwdsafe-input
@@ -84,7 +84,7 @@
                                 </div>
                             </div>
                             <div class="mb-2">
-                                <pwdsafe-label for="username" class="mb-1"
+                                <pwdsafe-label for="username" class="mb-1" required
                                     >Username</pwdsafe-label
                                 >
                                 <pwdsafe-input
@@ -95,7 +95,7 @@
                             </div>
                             <div class="mb-2">
                                 <div class="mb-2 flex items-end justify-between">
-                                    <pwdsafe-label for="password" class="mb-1">
+                                    <pwdsafe-label for="password" class="mb-1" required>
                                         Password
                                     </pwdsafe-label>
                                     <pwdsafe-passwordgen

--- a/resources/js/components/GroupActionsMenu.vue
+++ b/resources/js/components/GroupActionsMenu.vue
@@ -27,10 +27,14 @@
                     <div v-if="canCreateSubGroup" class="py-1">
                         <MenuItem v-slot="{ active }">
                             <a
-                                :href="'/groups/' + groupid + '/subgroups/create'"
+                                :href="
+                                    '/groups/' + groupid + '/subgroups/create'
+                                "
                                 :class="menuItemClass(active)"
                             >
-                                New sub-group
+                                <heroicons-folder-plus-icon
+                                    class="mr-1 h-5 w-5"
+                                />New sub-group
                             </a>
                         </MenuItem>
                     </div>
@@ -41,15 +45,16 @@
                             <a
                                 :href="'/groups/' + groupid + '/name'"
                                 :class="menuItemClass(active)"
-                            >
-                                Change name
+                                ><heroicons-pencil-square-icon
+                                    class="mr-1 h-5 w-5"
+                                />Change name
                             </a>
                         </MenuItem>
                         <MenuItem v-if="canManageMembers" v-slot="{ active }">
                             <a
                                 :href="'/groups/' + groupid + '/members'"
                                 :class="menuItemClass(active)"
-                            >
+                                ><heroicons-users-icon class="mr-1 h-5 w-5" />
                                 Manage members
                             </a>
                         </MenuItem>
@@ -63,17 +68,31 @@
                                 :class="menuItemClass(active)"
                                 @click="triggerImport"
                             >
+                                <heroicons-arrow-down-tray-icon
+                                    class="mr-1 h-5 w-5"
+                                />
                                 Import credentials
                             </button>
                         </MenuItem>
                         <MenuItem v-slot="{ active }">
                             <button
                                 type="button"
-                                :class="[menuItemClass(active), exporting ? 'opacity-50 cursor-not-allowed' : '']"
+                                :class="[
+                                    menuItemClass(active),
+                                    exporting
+                                        ? 'cursor-not-allowed opacity-50'
+                                        : '',
+                                ]"
                                 :disabled="exporting"
                                 @click="triggerExport"
-                            >
-                                {{ exporting ? 'Exporting…' : 'Export credentials' }}
+                            ><heroicons-arrow-up-tray-icon
+                                    class="mr-1 h-5 w-5"
+                                />
+                                {{
+                                    exporting
+                                        ? 'Exporting…'
+                                        : 'Export credentials'
+                                }}
                             </button>
                         </MenuItem>
                     </div>
@@ -83,9 +102,14 @@
                         <MenuItem v-slot="{ active }">
                             <a
                                 :href="'/groups/' + groupid + '/delete'"
-                                :class="[menuItemClass(active), 'text-red-600 dark:text-red-400']"
+                                :class="[
+                                    menuItemClass(active),
+                                    'text-red-600 dark:text-red-400',
+                                ]"
                             >
-                                <heroicons-trash-icon class="h-4 w-4 inline mr-1" />
+                                <heroicons-trash-icon
+                                    class="mr-1 inline h-4 w-4"
+                                />
                                 Delete group
                             </a>
                         </MenuItem>
@@ -141,7 +165,9 @@ const triggerImport = () => {
 
 const menuItemClass = (active: boolean) =>
     [
-        active ? 'bg-gray-100 dark:bg-gray-700 dark:text-white' : 'dark:bg-gray-600',
+        active
+            ? 'bg-gray-100 dark:bg-gray-700 dark:text-white'
+            : 'dark:bg-gray-600',
         'group flex w-full items-center px-4 py-2 text-sm text-gray-700 transition duration-150 ease-in-out hover:bg-gray-100 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-gray-200 dark:focus:bg-gray-700',
     ].join(' ')
 
@@ -149,14 +175,18 @@ const triggerExport = async () => {
     exporting.value = true
     try {
         const privkeyPem = loadPrivkey()
-        const { data: credentials } = await axios.get(`/api/groups/${props.groupid}/export-data`)
+        const { data: credentials } = await axios.get(
+            `/api/groups/${props.groupid}/export-data`,
+        )
 
         const rows = await Promise.all(
             credentials.map(async (cred: any) => ({
                 name: cred.name,
                 url: cred.url,
                 username: cred.username,
-                password: privkeyPem ? await decryptCredential(cred.data, privkeyPem) : cred.data,
+                password: privkeyPem
+                    ? await decryptCredential(cred.data, privkeyPem)
+                    : cred.data,
                 notes: cred.notes,
             })),
         )
@@ -168,7 +198,9 @@ const triggerExport = async () => {
             .slice(0, 200)
 
         const filename = `pwdsafe_export_${sanitized}_${new Date().toISOString().slice(0, 10)}.json`
-        const blob = new Blob([JSON.stringify(rows)], { type: 'application/json' })
+        const blob = new Blob([JSON.stringify(rows)], {
+            type: 'application/json',
+        })
         const url = URL.createObjectURL(blob)
         const a = document.createElement('a')
         a.href = url

--- a/resources/js/components/Label.vue
+++ b/resources/js/components/Label.vue
@@ -3,8 +3,18 @@
         class="block text-sm leading-5 font-medium text-gray-700 dark:text-gray-300"
     >
         <slot></slot>
+        <span v-if="required" class="ml-0.5 text-red-500" aria-hidden="true"
+            >*</span
+        >
     </label>
 </template>
 <script>
-export default {}
+export default {
+    props: {
+        required: {
+            type: Boolean,
+            default: false,
+        },
+    },
+}
 </script>

--- a/resources/js/components/ShareModal.vue
+++ b/resources/js/components/ShareModal.vue
@@ -32,7 +32,7 @@
                     <input type="checkbox" v-model="burnAfterRead" /> Burn after
                     read
                 </label>
-                <p class="text-sm italic">
+                <p class="text-sm italic text-red-500">
                     This allows anyone with the link to look at the data only
                     once.
                 </p>

--- a/resources/js/components/VaultSidebar.vue
+++ b/resources/js/components/VaultSidebar.vue
@@ -100,6 +100,7 @@ interface SidebarNode {
     name: string
     url: string
     credentialsCount: number
+    usersCount: number
     children: SidebarNode[]
 }
 

--- a/resources/js/components/VaultSidebarItem.vue
+++ b/resources/js/components/VaultSidebarItem.vue
@@ -32,10 +32,19 @@
                 <heroicons-folder-open-icon v-if="isActive" class="w-4 h-4 flex-shrink-0" />
                 <heroicons-folder-icon v-else class="w-4 h-4 flex-shrink-0" />
                 <span class="truncate">{{ node.name }}</span>
-                <span
-                    v-if="node.credentialsCount > 0"
-                    class="ml-auto flex-shrink-0 text-xs text-gray-400 dark:text-gray-500 tabular-nums"
-                >{{ node.credentialsCount }}</span>
+                <div class="ml-auto flex items-center gap-x-1.5 flex-shrink-0">
+                    <span
+                        v-if="node.usersCount > 1"
+                        class="flex items-center gap-x-0.5 text-xs text-gray-400 dark:text-gray-500 tabular-nums"
+                    >
+                        <heroicons-user-icon class="w-3 h-3" />
+                        {{ node.usersCount }}
+                    </span>
+                    <span
+                        v-if="node.credentialsCount > 0"
+                        class="ml-1 text-xs text-gray-400 dark:text-gray-500 tabular-nums"
+                    >{{ node.credentialsCount }}</span>
+                </div>
             </a>
         </div>
 
@@ -60,6 +69,7 @@ interface SidebarNode {
     name: string
     url: string
     credentialsCount: number
+    usersCount: number
     children: SidebarNode[]
 }
 

--- a/resources/views/components/icons/user.blade.php
+++ b/resources/views/components/icons/user.blade.php
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="size-3">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+</svg>

--- a/resources/views/group.blade.php
+++ b/resources/views/group.blade.php
@@ -30,6 +30,11 @@
             <span class="bg-gray-100 dark:bg-gray-600 text-xs text-gray-500 dark:text-gray-400 px-2 py-0.5 rounded-full font-normal">
                 {{ $credentials->count() }}
             </span>
+            @if($group->users()->count() > 1)
+                <span class="flex items-center gap-x-1 bg-gray-100 dark:bg-gray-600 text-xs text-gray-500 dark:text-gray-400 px-2 py-0.5 rounded-full font-normal">
+                    <x-icons.user /> {{ $group->users()->count() }}
+                </span>
+            @endif
         </h3>
 
         <div class="flex items-center gap-x-2">

--- a/resources/views/group/create.blade.php
+++ b/resources/views/group/create.blade.php
@@ -10,7 +10,7 @@
             </p>
         @endif
         <div class="form-group">
-            <label for="groupname" class="block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300 mb-1">Group name</label>
+            <label for="groupname" class="block text-sm font-medium leading-5 text-gray-700 dark:text-gray-300 mb-1">Group name<span class="ml-0.5 text-red-500">*</span></label>
             <input
                 type="text"
                 id="groupname"

--- a/tests/Feature/Api/SidebarTest.php
+++ b/tests/Feature/Api/SidebarTest.php
@@ -37,7 +37,7 @@ class SidebarTest extends TestCase
         $response = $this->getJson('/api/sidebar')->assertOk();
 
         $response->assertJsonStructure([
-            'private' => ['id', 'name', 'url', 'credentialsCount', 'children'],
+            'private' => ['id', 'name', 'url', 'credentialsCount', 'usersCount', 'children'],
             'shared',
         ]);
 


### PR DESCRIPTION
This is a very small pr, but yes. The changes simply include:

1. Passwords now show 16 password masks instead of indicating the actual length of specific password for a bit of extra security.
<img width="643" height="814" alt="image" src="https://github.com/user-attachments/assets/bbd4aa8e-7387-4714-b81c-94281a6c6b62" />

2. Required fields in create & view/edit forms are now clearly marked with *.

3. Added placeholders for links in the create form and fixed the styling for the open-link icon inside the button.

4. Added member count of those who are part of the same group as the user (at the top of the group table and in the sidebar).

5. Added icons for the actions in the GroupActionMenu to make it easier to navigate.

And well...added a highlight of this text
<img width="550" height="139" alt="image" src="https://github.com/user-attachments/assets/3d6a0f2e-92d6-4f70-957b-d3e118c24dfc" />


There were more things I initially wanted to change, but apparently those have already been fixed :p