### PR TITLE
Add a confirmation view for deleting a group member

### DIFF
--- a/app/Http/Controllers/ManageGroupMembersController.php
+++ b/app/Http/Controllers/ManageGroupMembersController.php
@@ -12,13 +12,18 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\Response;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Validation\Rule;
 
 class ManageGroupMembersController extends Controller
 {
-    public function confirmRemove(Group $group, User $user)
+    public function confirmRemove(Group $group, User $user): RedirectResponse|View
     {
         $this->authorize('administer', $group);
+        if (Auth::user()->is($user)) {
+            abort(403, 'You cannot remove yourself from this group.');
+        }
+
         return view('group.member-delete', compact('group', 'user'));
     }
 
@@ -39,7 +44,7 @@ class ManageGroupMembersController extends Controller
         Encryptedcredential::whereIn('credentialid', $group->credentials()->pluck('id'))->where('userid', $data['userid'])->delete();
         User::find($data['userid'])->groups()->detach($group);
 
-        return redirect()->route('groupManageMembers', ['group' => $group])->with('success', 'Group member successfully removed.');
+        return redirect()->route('groupManageMembers', ['group' => $group]);
     }
 
     public function update(Request $request, Group $group, User $user): Response|Application|ResponseFactory

--- a/app/Http/Controllers/ManageGroupMembersController.php
+++ b/app/Http/Controllers/ManageGroupMembersController.php
@@ -16,6 +16,12 @@ use Illuminate\Validation\Rule;
 
 class ManageGroupMembersController extends Controller
 {
+    public function confirmRemove(Group $group, User $user)
+    {
+        $this->authorize('administer', $group);
+        return view('group.member-delete', compact('group', 'user'));
+    }
+
     public function index(Group $group): Factory|View|Application
     {
         $this->authorize('administer', $group);
@@ -33,7 +39,7 @@ class ManageGroupMembersController extends Controller
         Encryptedcredential::whereIn('credentialid', $group->credentials()->pluck('id'))->where('userid', $data['userid'])->delete();
         User::find($data['userid'])->groups()->detach($group);
 
-        return redirect()->back();
+        return redirect()->route('groupManageMembers', ['group' => $group])->with('success', 'Group member successfully removed.');
     }
 
     public function update(Request $request, Group $group, User $user): Response|Application|ResponseFactory

--- a/resources/views/group/member-delete.blade.php
+++ b/resources/views/group/member-delete.blade.php
@@ -1,0 +1,15 @@
+@php $activeGroupId = $group->id; @endphp
+@extends('layouts.vault')
+@section('content')
+<div>
+    <pwdsafe-alert theme="danger" classes="max-w-2xl mx-auto">
+        <p class="mb-4"><strong>Are you sure</strong> you wish to remove member <strong>{{ $user->name ?? $user->email }}</strong> from group "<strong>{{ $group->name }}</strong>"?</p>
+        <form method="post" action="{{ url('/groups/' . $group->id . '/members') }}">
+            @method('delete')
+            @csrf
+            <input type="hidden" name="userid" value="{{ $user->id }}">
+            <pwdsafe-button theme="danger" type="submit">Yes, remove member</pwdsafe-button>
+        </form>
+    </pwdsafe-alert>
+</div>
+@endsection

--- a/resources/views/group/member-delete.blade.php
+++ b/resources/views/group/member-delete.blade.php
@@ -4,7 +4,7 @@
 <div>
     <pwdsafe-alert theme="danger" classes="max-w-2xl mx-auto">
         <p class="mb-4"><strong>Are you sure</strong> you wish to remove member <strong>{{ $user->name ?? $user->email }}</strong> from group "<strong>{{ $group->name }}</strong>"?</p>
-        <form method="post" action="{{ url('/groups/' . $group->id . '/members') }}">
+        <form method="post" action="{{ route('groupMemberDelete', [$group->id, $user->id]) }}">
             @method('delete')
             @csrf
             <input type="hidden" name="userid" value="{{ $user->id }}">

--- a/resources/views/group/share.blade.php
+++ b/resources/views/group/share.blade.php
@@ -44,12 +44,9 @@
                                         </td>
                                         <td class="px-6 py-4 whitespace-no-wrap text-right text-sm leading-5 font-medium">
                                             @if (!auth()->user()->is($user))
-                                                <form method="post">
-                                                    @csrf
-                                                    @method('delete')
-                                                    <input type="hidden" name="userid" value="{{ $user->id }}">
-                                                    <pwdsafe-button theme="danger" type="submit">Remove</pwdsafe-button>
-                                                </form>
+                                                <a href="{{ route('memberDeleteConfirm', ['group' => $group, 'user' => $user]) }}" class="inline-block">
+                                                    <pwdsafe-button theme="danger" type="button">Remove</pwdsafe-button>
+                                                </a>
                                             @endif
                                         </td>
                                     </tr>

--- a/routes/web.php
+++ b/routes/web.php
@@ -59,6 +59,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/groups/{group}/add', [GroupController::class, 'addCredential'])->name('addCredentials');
     Route::post('/groups/{group}/add', [GroupController::class, 'storeCredential']);
     Route::get('/groups/{group}/members', [ManageGroupMembersController::class, 'index'])->name('groupManageMembers');
+    Route::get('/groups/{group}/members/{user}/delete', [ManageGroupMembersController::class, 'confirmRemove'])->name('memberDeleteConfirm');
     Route::post('/groups/{group}/members', [ManageGroupMembersController::class, 'store']);
     Route::delete('/groups/{group}/members', [ManageGroupMembersController::class, 'destroy']);
     Route::patch('/groups/{group}/members/{user}', [ManageGroupMembersController::class, 'update']);

--- a/routes/web.php
+++ b/routes/web.php
@@ -61,7 +61,7 @@ Route::middleware('auth')->group(function () {
     Route::get('/groups/{group}/members', [ManageGroupMembersController::class, 'index'])->name('groupManageMembers');
     Route::get('/groups/{group}/members/{user}/delete', [ManageGroupMembersController::class, 'confirmRemove'])->name('memberDeleteConfirm');
     Route::post('/groups/{group}/members', [ManageGroupMembersController::class, 'store']);
-    Route::delete('/groups/{group}/members', [ManageGroupMembersController::class, 'destroy']);
+    Route::delete('/groups/{group}/members', [ManageGroupMembersController::class, 'destroy'])->name('groupMemberDelete');
     Route::patch('/groups/{group}/members/{user}', [ManageGroupMembersController::class, 'update']);
     Route::get('/groups/{group}/delete', [GroupDeleteController::class, 'index']);
     Route::get('/groups/{group}/name', [GroupChangeNameController::class, 'index']);

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -356,7 +356,8 @@ class GroupTest extends TestCase
         $this->post('/groups/create', ['groupname' => 'testgroup']);
 
         $group = \App\Group::orderBy('id', 'desc')->first();
-        $user2 = \App\User::registerUser('second@email.com', 'password');
+        \App\User::registerUser('second@email.com', 'password');
+        $user2 = \App\User::where('email', 'second@email.com')->first();
 
         $group->users()->attach($user2, ['permission' => 'read']);
         $response = $this->get('/groups/' . $group->id . '/members/' . $user2->id . '/delete');

--- a/tests/Feature/GroupTest.php
+++ b/tests/Feature/GroupTest.php
@@ -351,6 +351,23 @@ class GroupTest extends TestCase
         ])->assertStatus(422);
     }
 
+    public function testMemberRemovalConfirmation(): void
+    {
+        $this->post('/groups/create', ['groupname' => 'testgroup']);
+
+        $group = \App\Group::orderBy('id', 'desc')->first();
+        $user2 = \App\User::registerUser('second@email.com', 'password');
+
+        $group->users()->attach($user2, ['permission' => 'read']);
+        $response = $this->get('/groups/' . $group->id . '/members/' . $user2->id . '/delete');
+
+        $response->assertOk();
+        $response->assertSee('Are you sure');
+
+        $this->delete('/groups/' . $group->id . '/members', ['userid' => $user2->id]);
+        $this->assertFalse($group->fresh()->users->contains($user2));
+    }
+
     public function testUnsharingGroup(): void
     {
         $this->post('/groups/create', [


### PR DESCRIPTION
Just added confirmation before deleting a group member, previously it'd just delete them right away after pressing the "Remove" button. The confirmation page mimics the one you already have for deleting a group.

<img width="2271" height="1113" alt="image" src="https://github.com/user-attachments/assets/d69567bc-89fe-481d-917b-c3cddd3239bc" />

// Also, thank you for adding the arm64 build :p 