### PR TITLE
Remove extra space after 'Password' in CredentialCard

### DIFF
--- a/resources/js/components/CredentialCard.vue
+++ b/resources/js/components/CredentialCard.vue
@@ -109,8 +109,7 @@
                                         class="mb-1"
                                         required
                                     >
-                                        Password
-                                    </pwdsafe-label>
+                                        Password</pwdsafe-label>
                                     <pwdsafe-passwordgen
                                         v-if="canUpdate"
                                         button-size="small"


### PR DESCRIPTION
Hi again, I just noticed that I accidentally left an extra space after the 'Password' text in CredentialCard.vue while adding required markers. It looks like there was only one effected space. Sorry about this :sweat_smile: 