### PR TITLE
Mask password length in CredentialCard

### DIFF
--- a/resources/js/components/CredentialCard.vue
+++ b/resources/js/components/CredentialCard.vue
@@ -125,7 +125,7 @@
                                     <input
                                         v-if="!passwordVisible"
                                         type="password"
-                                        :value="password"
+                                        value="****************"
                                         :placeholder="
                                             !passwordLoaded ? 'Loading...' : ''
                                         "


### PR DESCRIPTION
Okay, so I got a bit confused here...because this is a change I was supposed to make in my first pr. I assumed you rolled this back later on, but I checked and I cannot see any changes related to this, even in my own commits, so I assume I rolled back this change at some point and did not notice :sweat_smile:.

Anywho, I think it's better to mask the length of the password in the view card.